### PR TITLE
x86: Add new virtio_blk_sample test

### DIFF
--- a/apps/x86/virtio_blk_sample/CMakeLists.txt
+++ b/apps/x86/virtio_blk_sample/CMakeLists.txt
@@ -1,0 +1,35 @@
+#
+# Copyright 2020, DornerWorks
+#
+# This software may be distributed and modified according to the terms of
+# the BSD 2-Clause license. Note that NO WARRANTY is provided.
+# See "LICENSE_BSD2.txt" for details.
+#
+# @TAG(DORNERWORKS_BSD)
+#
+
+cmake_minimum_required(VERSION 3.8.2)
+
+project(virtio_blk_sample)
+
+# Include CAmkES VM helper functions
+include(${CAMKES_VM_HELPERS_PATH})
+find_package(camkes-vm-linux REQUIRED)
+include(${CAMKES_VM_LINUX_HELPERS_PATH})
+
+# Declare VM components: Init0
+DeclareCAmkESVM(Init0)
+
+# Get Default Linux VM files
+GetDefaultLinuxKernelFile(kernel_file)
+GetDefaultLinuxRootfsFile(rootfs_file)
+
+# Decompress Linux Kernel image and add to file server
+DecompressLinuxKernel(extract_linux_kernel decompressed_kernel ${kernel_file})
+AddToFileServer("bzimage" ${decompressed_kernel} DEPENDS extract_linux_kernel)
+
+AddToFileServer("rootfs.cpio" ${rootfs_file})
+
+DeclareCAmkESVMRootServer(virtio_blk_sample.camkes
+    CPP_FLAGS -DLibSatadriversAHCIEnable
+    )

--- a/apps/x86/virtio_blk_sample/app_settings.cmake
+++ b/apps/x86/virtio_blk_sample/app_settings.cmake
@@ -1,0 +1,25 @@
+#
+# Copyright 2019, DornerWorks
+#
+# This software may be distributed and modified according to the terms of
+# the BSD 2-Clause license. Note that NO WARRANTY is provided.
+# See "LICENSE_BSD2.txt" for details.
+#
+# @TAG(DORNERWORKS_BSD)
+#
+
+cmake_minimum_required(VERSION 3.8.2)
+
+# Define kernel config options
+set(KernelSel4Arch x86_64 CACHE STRING "" FORCE)
+
+set(KernelMaxNumNodes 4 CACHE STRING "" FORCE)
+set(KernelHugePage OFF CACHE BOOL "" FORCE)
+
+ApplyCommonSimulationSettings(${KernelArch})
+set(KernelIOMMU ON CACHE BOOL "" FORCE)
+
+# Enable sataserver
+set(LibSatadrivers ON CACHE BOOL "" FORCE)
+
+set(CAmkESVMDestHardware "optiplex" CACHE STRING "" FORCE)

--- a/apps/x86/virtio_blk_sample/virtio_blk_sample.camkes
+++ b/apps/x86/virtio_blk_sample/virtio_blk_sample.camkes
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020, DornerWorks
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DORNERWORKS_BSD)
+ */
+
+import <VM/vm.camkes>;
+
+#include <configurations/vm.h>
+#include <configurations/sata.h>
+
+#define VM_GUEST_CMDLINE "earlyprintk=ttyS0,115200 console=ttyS0,115200 i8042.nokbd=y i8042.nomux=y \
+i8042.noaux=y noisapnp pci=nomsi,noacpi nolapic_timer"
+
+component Init0 {
+    VM_INIT_DEF()
+    VM_INIT_SATA()
+}
+
+assembly {
+    composition {
+        VM_COMPOSITION_DEF()
+        SATA_COMPOSITION_DEF()
+
+        VM_PER_VM_COMP_DEF(0)
+        VM_SATA_CONNECTIONS(0)
+    }
+
+    configuration {
+        VM_CONFIGURATION_DEF()
+        VM_PER_VM_CONFIG_DEF(0)
+
+        VM_SATA_CONFIG()
+
+        sataserver.ioports = "0xf090:0xf097,0xf080:0xf083,0xf070:0xf077,0xf060:0xf063,0xf020:0xf03f";
+        sataserver.iospaces = "0x12:0x0:0x1f:2";
+        sataserver.pci_bdfs = "0x0:0x1f.2";
+        sataserver.iospace_id = 0x12;
+        sataserver.num_bdfs = 1;
+        sataserver.drive = 0;
+
+        vm0.simple_untyped25_pool = 95;
+        vm0.heap_size = 0x2000000;
+        vm0.dma_pool = 0x20000;
+        vm0.guest_ram_mb = 1900;
+        vm0.kernel_cmdline = VM_GUEST_CMDLINE;
+        vm0.kernel_image = "bzimage";
+        vm0.kernel_relocs = "bzimage";
+        vm0.initrd_image = "rootfs.cpio";
+        vm0.iospace_domain = 0x0f;
+        vm0.cnode_size_bits = 24;
+
+        vm0.sched_ctrl = [0, 1, 2, 3, 4, 5];
+
+        vm0.sataserver_iface_attributes = "0";
+        vm0.sataserver_iface_partitions = [1];  /* Physical Partition assigned to VM0 */
+
+        vm0.init_cons = [
+            {"init":"make_virtio_blk"},
+        ];
+
+        vm0.pci_devices_iospace = 1;
+    }
+}


### PR DESCRIPTION
Merge Dornerworks' patches to our repo for development purposes. There is a PR for upstream aswell, but it hasn't been merged yet. See https://github.com/seL4/camkes-vm-examples/pull/4

This new application is used as an example to showcase the VirtIO block
driver. This application is based off of Dornerworks' test application
in this commit: 3f80ae7d on Dornerworks' fork of camkes-vm-examples on
GitHub.

Signed-off-by: Damon Lee <Damon.Lee@data61.csiro.au>